### PR TITLE
Remove deinit in BasicNavigator that causes crashes on background thread

### DIFF
--- a/Source/Coordination/BasicNavigator.swift
+++ b/Source/Coordination/BasicNavigator.swift
@@ -18,8 +18,4 @@ open class BasicNavigator: NavigatorCommonImpl {
     self.navigationController = navigationController
     super.init(parent: parent, navigationController: navigationController)
   }
-
-  deinit {
-    navigationController.setViewControllers([], animated: false)
-  }
 }


### PR DESCRIPTION
This isn't needed as it isn't the properly want to break cycles. And it crashes if deinit is on a background thread.