### PR TITLE
Fix compilation under Xcode 13 beta 5

### DIFF
--- a/Source/Coordination/NavigationCoordinatorNavigator.swift
+++ b/Source/Coordination/NavigationCoordinatorNavigator.swift
@@ -20,7 +20,7 @@ open class NavigationCoordinatorNavigator: NavigatorCommonImpl {
   }
 }
 
-open class NavigatorCommonImpl: NSObject {
+open class NavigatorCommonImpl: NSObject, Navigator {
   private final class RemovalCompletionBox {
     let completion: Navigator.RemovalCompletion
 
@@ -56,7 +56,7 @@ open class NavigatorCommonImpl: NSObject {
 
 // MARK: - NavigatorType
 
-extension NavigatorCommonImpl: Navigator {
+extension NavigatorCommonImpl {
   public func present(
     _ viewController: UIViewController,
     animated: Bool,


### PR DESCRIPTION
I believe this is a compiler error:

> MinervaCoordinator.BasicNavigator:1:12: Main actor-isolated class 'BasicNavigator' has different actor isolation from nonisolated superclass 'NavigatorCommonImpl'

However, the workaround is fairly minor, so it feels okay to just change it.